### PR TITLE
Ability to exclude files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,6 @@ which is included and writed on filesystem
 | `ouputPath` | `assets/javascript/` | Customize output location of packed script |
 | `uglify` | `true` | Enable/disable script uglify |
 | `uglifyOptions` | `{}` | Options passed to [uglify](https://www.npmjs.com/package/uglify-js) |
+| `exclude` | `[]` | [multimatch](https://www.npmjs.com/package/multimatch) patterns for file exclusion from build |
 
 > hint: metalsmith-js-packer use debug

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const uglify = require('uglify-js');
+const uglify = require('uglify-es');
 const rp = require('request-promise');
 
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const uglify = require('uglify-es');
 const rp = require('request-promise');
+const multimatch = require('multimatch');
 
 
 module.exports = options => {
@@ -18,6 +19,7 @@ module.exports = options => {
   let ouputPath = options.ouputPath || 'assets/javascript/';
   let uglifyEnabled = options.uglify || true;
   let uglifyOptions = options.uglifyOptions || {};
+  let exclude = options.exclude || [];
 
   return (files, metalsmith, done) => {
     let scripts = {};
@@ -28,6 +30,11 @@ module.exports = options => {
     for (let file in files) {
       // parse only builded html files
       if (!file.endsWith('.html')) {
+        continue;
+      }
+
+      if (multimatch([file], exclude).length > 0) {
+        debug(`skipping excluded file ${file}`);
         continue;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,29 @@
         "json-stable-stringify": "1.0.1"
       }
     },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -37,6 +60,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -63,6 +91,15 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
         "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "caseless": {
@@ -105,6 +142,11 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -453,10 +495,29 @@
         "mime-db": "1.27.0"
       }
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
+      }
     },
     "nth-check": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,14 +106,6 @@
         "delayed-stream": "1.0.0"
       }
     },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -156,6 +148,14 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "delayed-stream": {
@@ -254,11 +254,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "har-schema": {
       "version": "1.0.5",
@@ -458,6 +453,11 @@
         "mime-db": "1.27.0"
       }
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "nth-check": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
@@ -633,13 +633,20 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
-    "uglify-js": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.15.tgz",
-      "integrity": "sha1-qssyOoRrI0YCJw3q2KMkQaiAb0I=",
+    "uglify-es": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.3.tgz",
+      "integrity": "sha512-Nuo5gkv/Q6PmLa+Ui2LvK+87YdMAcuXfRIWF0uVfkHVSfpT3Ue0euCSu4t0b8xv4Bt05lmXUT8bLI9OmnyPj8A==",
       "requires": {
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cheerio": "^0.22.0",
+    "debug": "^3.1.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
-    "uglify-js": "^3.0.15"
+    "uglify-es": "^3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bluebird": "^3.5.0",
     "cheerio": "^0.22.0",
     "debug": "^3.1.0",
+    "multimatch": "^2.1.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "uglify-es": "^3.1.3"


### PR DESCRIPTION
Hi @stafyniaksacha ! Hope you're doing fine! Thanks for this nice Metalsmith plugin.

In this PR, I added the ability to exclude files from the build process. It uses [multimatch](https://www.npmjs.com/package/multimatch) for pattern matching. It basically adds the `exclude` attribute to the `options` object. The `exclude` attribute is an array of patterns in the form of minimatch (wildcards and globs are allowed). For example

```javascript
metalsmith
  .use(jsPacker({
      siteRootPath: options.build.path,
      inline: false,
      exclude: ['partials/**/*', 'layouts/**/*']
    }))
```

### Boyscouting
I also replaced the `uglify-js` with `uglify-es` for compatibility with ES6.