### PR TITLE
Fixed uglify option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = options => {
   let inline = options.inline || false;
   let siteRootPath = options.siteRootPath || '/';
   let ouputPath = options.ouputPath || 'assets/javascript/';
-  let uglifyEnabled = options.uglify || true;
+  let uglifyEnabled = options.uglify !== false;
   let uglifyOptions = options.uglifyOptions || {};
 
   return (files, metalsmith, done) => {


### PR DESCRIPTION
The `uglify` option did not work properly in a way that it was not possible
to deactivate uglification. I fixed it such that an explicit `false`
value will deactivate it. Each other value or none value at all will
leave it activated by default.